### PR TITLE
Fix rle encoding return format

### DIFF
--- a/src/rle.py
+++ b/src/rle.py
@@ -3,7 +3,9 @@ import numpy as np
 
 def rle_encode(arr):
     if len(arr) == 0:
-        return [], [], []
+        # keep the return format consistent with the non-empty case
+        # which returns two arrays: lengths and values
+        return [], []
 
     x = np.copy(arr)
     first_dismatch = np.array(x[1:] != x[:-1])


### PR DESCRIPTION
## Summary
- ensure `rle_encode` returns two values even for empty arrays

## Testing
- `python -m compileall src`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_684d4628a2ac83328002f276f1f8d85b