### PR TITLE
Add shakuhachi tablature prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,6 @@ The aim of this project is to develop a sheet music reader. This is called Optic
 - [OpenCV](https://opencv.org/)
 - [scikit-learn](https://scikit-learn.org/stable/)
 - [scikit-image](https://scikit-image.org/)
+
+### Shakuhachi Tablature Prototype
+A proof-of-concept pipeline for vertical shakuhachi notation lives under `src/tablature/shakuhachi`. It reuses the existing preprocessing and classifier but applies a custom segmenter for vertical measures.

--- a/src/tablature/shakuhachi/main.py
+++ b/src/tablature/shakuhachi/main.py
@@ -1,0 +1,56 @@
+from commonfunctions import gray_img
+from pre_processing import IsHorizontal, deskew, rotation, get_gray, get_thresholded, get_closer
+from fit import predict
+from skimage.filters import threshold_otsu
+from glob import glob
+from skimage import io
+import argparse
+
+from .segmenter import ShakuhachiSegmenter
+
+# Simple mapping from shakuhachi symbols to MIDI note names
+SHAKU_MAP = {
+    'ro': 'C4/4',
+    'tsu': 'D4/4',
+    're': 'E4/4',
+    'chi': 'F4/4',
+}
+
+
+def recognize_stub(out_file, regions):
+    """Placeholder recognition using the existing classifier."""
+    for region in regions:
+        labels = predict((255 * (1 - region)).astype(np.uint8))
+        label = labels[0]
+        out_file.write(SHAKU_MAP.get(label, f"{label}"))
+        out_file.write("\n")
+
+
+def main(input_path, output_path):
+    imgs_path = sorted(glob(f"{input_path}/*"))
+    for img_path in imgs_path:
+        img_name = img_path.split('/')[-1].split('.')[0]
+        out_file = open(f"{output_path}/{img_name}.txt", "w")
+        img = io.imread(img_path)
+        img = gray_img(img)
+        horizontal = IsHorizontal(img)
+        if not horizontal:
+            theta = deskew(img)
+            img = rotation(img, theta)
+            img = get_gray(img)
+            img = get_thresholded(img, threshold_otsu(img))
+            img = get_closer(img)
+
+        bin_img = get_thresholded(get_gray(img), threshold_otsu(get_gray(img)))
+
+        segmenter = ShakuhachiSegmenter(bin_img)
+        recognize_stub(out_file, segmenter.regions_with_staff)
+        out_file.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("inputfolder", help="Input folder")
+    parser.add_argument("outputfolder", help="Output folder")
+    args = parser.parse_args()
+    main(args.inputfolder, args.outputfolder)

--- a/src/tablature/shakuhachi/segmenter.py
+++ b/src/tablature/shakuhachi/segmenter.py
@@ -1,0 +1,39 @@
+import numpy as np
+from commonfunctions import histogram, get_line_indices
+
+
+class ShakuhachiSegmenter:
+    """Segment vertical shakuhachi notation into measure boxes."""
+
+    def __init__(self, bin_img):
+        self.bin_img = bin_img
+        self.segment()
+
+    def segment(self):
+        # Histogram along columns to find vertical boundaries
+        hist = histogram(self.bin_img.T, 0.8)
+        indices = get_line_indices(hist)
+        if len(indices) < 2:
+            self.regions_with_staff = [self.bin_img]
+            self.most_common = 0
+            return
+
+        lines = []
+        for idx in indices:
+            lines.append(((idx, 0), (idx, self.bin_img.shape[0] - 1)))
+
+        end_of_staff = []
+        for idx, line in enumerate(lines):
+            if idx > 0 and (line[0][0] - end_of_staff[-1][0] < 20):
+                continue
+            x0, y0 = line[0]
+            end_of_staff.append((x0, y0))
+
+        regions = []
+        for i in range(len(end_of_staff) - 1):
+            x0 = end_of_staff[i][0]
+            x1 = end_of_staff[i + 1][0]
+            region = self.bin_img[:, x0:x1]
+            regions.append(region)
+        self.regions_with_staff = regions
+        self.most_common = 0


### PR DESCRIPTION
## Summary
- prototype vertical segmentation for shakuhachi notation
- basic demo script reusing classifier
- document shakuhachi prototype in README

## Testing
- `python3 -m py_compile src/tablature/shakuhachi/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684d46fe41788332b14bc06e0a9b9c6b