### PR TITLE
Add typed Pydantic config for shakuhachi

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,8 @@ The aim of this project is to develop a sheet music reader. This is called Optic
 - [scikit-image](https://scikit-image.org/)
 
 ### Shakuhachi Tablature Prototype
-A proof-of-concept pipeline for vertical shakuhachi notation lives under `src/tablature/shakuhachi`. It reuses the existing preprocessing and classifier but applies a custom segmenter for vertical measures.
+A proof-of-concept pipeline for vertical shakuhachi notation lives under
+`src/tablature/shakuhachi`. It reuses the existing preprocessing and classifier
+but applies a custom segmenter for vertical measures. Configuration is handled
+via a small [Pydantic](https://docs.pydantic.dev/) model. See the README in that
+directory for training and usage instructions.

--- a/requirements.yml
+++ b/requirements.yml
@@ -172,3 +172,4 @@ dependencies:
     - autopep8==1.5.4
     - pycodestyle==2.6.0
     - toml==0.10.2
+    - pydantic

--- a/src/fit.py
+++ b/src/fit.py
@@ -5,12 +5,20 @@ from train import *
 import os
 import pickle
 
-def predict(img):
-    if not os.path.exists('trained_models/nn_trained_model_hog.sav'):
-        print('Please wait while training the NN-HOG model....')
-        train('NN', 'hog', 'nn_trained_model_hog')
+def predict(img: np.ndarray, model_path: str = 'trained_models/nn_trained_model_hog.sav', dataset_path: str = DEFAULT_DATASET_PATH) -> np.ndarray:
+    """Predict symbol label for the given image using a saved model.
 
-    model = pickle.load(open('trained_models/nn_trained_model_hog.sav', 'rb'))
+    If the model file does not exist it will be trained automatically using the
+    dataset at ``dataset_path``. ``model_path`` should point to a pickle file
+    produced by :func:`train.train`.
+    """
+
+    if not os.path.exists(model_path):
+        print('Please wait while training the NN-HOG model....')
+        base = os.path.splitext(os.path.basename(model_path))[0]
+        train('NN', 'hog', base, dataset_path=dataset_path)
+
+    model = pickle.load(open(model_path, 'rb'))
     features = extract_features(img, 'hog')
     labels = model.predict([features])
 
@@ -21,3 +29,4 @@ def predict(img):
 #     img = cv2.imread('testresult/0_6.png')
 #     labels = predict(img)
 #     print(labels)
+

--- a/src/tablature/shakuhachi/README.md
+++ b/src/tablature/shakuhachi/README.md
@@ -1,0 +1,46 @@
+# Shakuhachi Tablature Prototype
+
+This directory contains a minimal pipeline for optical music recognition of
+vertical shakuhachi notation. It reuses the preprocessing and classifier logic
+from the main project but applies a custom segmenter designed for the vertical
+box layout typically found in shakuhachi scores. Runtime settings are stored in
+`config.py` using [Pydantic](https://docs.pydantic.dev/).
+
+## Training
+
+The recognition step relies on a neural network classifier trained on isolated
+symbols. Training data should be placed under `train_data/shakuhachi` where each
+symbol has its own subdirectory containing sample images in PNG format:
+
+```
+train_data/
+    shakuhachi/
+        ro/
+        tsu/
+        re/
+        chi/
+        ...
+```
+
+To train the classifier run `train.py` in this folder:
+
+```
+python train.py
+```
+
+The trained model will be written to
+`trained_models/shakuhachi_model.sav`.
+
+## Usage
+
+Once a model has been trained you can process a folder of score images using
+`main.py`:
+
+```
+python main.py <input_folder> <output_folder> \
+    --model-path trained_models/shakuhachi_model.sav \
+    --dataset-path train_data/shakuhachi
+```
+
+Each output file contains the recognized shakuhachi symbols mapped to simple
+MIDI note names as defined in `SHAKU_MAP` in `main.py`.

--- a/src/tablature/shakuhachi/config.py
+++ b/src/tablature/shakuhachi/config.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+
+class ShakuhachiConfig(BaseModel):
+    """Configuration for Shakuhachi OMR."""
+
+    model_path: str = Field(
+        'trained_models/shakuhachi_model.sav',
+        description='Path to the trained model file')
+    dataset_path: str = Field(
+        'train_data/shakuhachi',
+        description='Directory containing training data')
+

--- a/src/tablature/shakuhachi/main.py
+++ b/src/tablature/shakuhachi/main.py
@@ -1,15 +1,27 @@
+from typing import Iterable, IO
+
 from commonfunctions import gray_img
-from pre_processing import IsHorizontal, deskew, rotation, get_gray, get_thresholded, get_closer
+from pre_processing import (
+    IsHorizontal,
+    deskew,
+    rotation,
+    get_gray,
+    get_thresholded,
+    get_closer,
+)
 from fit import predict
+import numpy as np
 from skimage.filters import threshold_otsu
 from glob import glob
 from skimage import io
 import argparse
 
+from .config import ShakuhachiConfig
+
 from .segmenter import ShakuhachiSegmenter
 
 # Simple mapping from shakuhachi symbols to MIDI note names
-SHAKU_MAP = {
+SHAKU_MAP: dict[str, str] = {
     'ro': 'C4/4',
     'tsu': 'D4/4',
     're': 'E4/4',
@@ -17,16 +29,33 @@ SHAKU_MAP = {
 }
 
 
-def recognize_stub(out_file, regions):
-    """Placeholder recognition using the existing classifier."""
+def recognize_stub(out_file: IO[str], regions: Iterable[np.ndarray], cfg: ShakuhachiConfig) -> None:
+    """Recognize regions using the existing classifier.
+
+    Parameters
+    ----------
+    out_file:
+        Open file handle for writing recognized labels.
+    regions:
+        Iterable of binary numpy arrays corresponding to notation boxes.
+    cfg:
+        Runtime configuration.
+    """
+
     for region in regions:
-        labels = predict((255 * (1 - region)).astype(np.uint8))
+        labels = predict(
+            (255 * (1 - region)).astype(np.uint8),
+            model_path=cfg.model_path,
+            dataset_path=cfg.dataset_path,
+        )
         label = labels[0]
         out_file.write(SHAKU_MAP.get(label, f"{label}"))
         out_file.write("\n")
 
 
-def main(input_path, output_path):
+def main(input_path: str, output_path: str, cfg: ShakuhachiConfig) -> None:
+    """Run the Shakuhachi OMR pipeline."""
+
     imgs_path = sorted(glob(f"{input_path}/*"))
     for img_path in imgs_path:
         img_name = img_path.split('/')[-1].split('.')[0]
@@ -44,7 +73,7 @@ def main(input_path, output_path):
         bin_img = get_thresholded(get_gray(img), threshold_otsu(get_gray(img)))
 
         segmenter = ShakuhachiSegmenter(bin_img)
-        recognize_stub(out_file, segmenter.regions_with_staff)
+        recognize_stub(out_file, segmenter.regions_with_staff, cfg)
         out_file.close()
 
 
@@ -52,5 +81,16 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("inputfolder", help="Input folder")
     parser.add_argument("outputfolder", help="Output folder")
+    parser.add_argument(
+        "--model-path",
+        default="trained_models/shakuhachi_model.sav",
+        help="Trained model file",
+    )
+    parser.add_argument(
+        "--dataset-path",
+        default="train_data/shakuhachi",
+        help="Training data directory",
+    )
     args = parser.parse_args()
-    main(args.inputfolder, args.outputfolder)
+    cfg = ShakuhachiConfig(model_path=args.model_path, dataset_path=args.dataset_path)
+    main(args.inputfolder, args.outputfolder, cfg)

--- a/src/tablature/shakuhachi/segmenter.py
+++ b/src/tablature/shakuhachi/segmenter.py
@@ -37,3 +37,4 @@ class ShakuhachiSegmenter:
             regions.append(region)
         self.regions_with_staff = regions
         self.most_common = 0
+

--- a/src/tablature/shakuhachi/train_model.py
+++ b/src/tablature/shakuhachi/train_model.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from typing import Optional
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from train import train
+from .config import ShakuhachiConfig
+
+
+def train_shakuhachi(cfg: Optional[ShakuhachiConfig] = None) -> None:
+    """Train a classifier for shakuhachi notation symbols."""
+    cfg = cfg or ShakuhachiConfig()
+    train('NN', 'hog', 'shakuhachi_model', dataset_path=cfg.dataset_path)
+
+
+if __name__ == "__main__":
+    train_shakuhachi()
+


### PR DESCRIPTION
## Summary
- add small Pydantic-based config model
- type hint shakuhachi utilities and training functions
- expose CLI options for model and dataset paths
- document typed config in READMEs
- include `pydantic` in requirements

## Testing
- `python -m py_compile src/tablature/shakuhachi/main.py src/tablature/shakuhachi/segmenter.py src/tablature/shakuhachi/train_model.py src/fit.py src/train.py`
- `python src/tablature/shakuhachi/train_model.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684d4996705c8332b67a3611dd0e5c86